### PR TITLE
comment_form variable referenced before assignment

### DIFF
--- a/Chapter02/mysite/blog/views.py
+++ b/Chapter02/mysite/blog/views.py
@@ -45,6 +45,7 @@ def post_detail(request, year, month, day, post):
     comments = post.comments.filter(active=True)
 
     new_comment = None
+    comment_form = None
 
     if request.method == 'POST':
         # A comment was posted


### PR DESCRIPTION
This variable is declared inside a `if` statement, so it is not accesible later in the `return` statement. At least I have experienced this bug following the chapter 2.