### PR TITLE
Fix order of arguments for redis.Redis.zincrby()

### DIFF
--- a/Chapter06/bookmarks/images/views.py
+++ b/Chapter06/bookmarks/images/views.py
@@ -51,7 +51,7 @@ def image_detail(request, id, slug):
     # increment total image views by 1
     total_views = r.incr('image:{}:views'.format(image.id))
     # increment image ranking by 1
-    r.zincrby('image_ranking', image.id, 1)
+    r.zincrby('image_ranking', 1, image.id)
     return render(request,
                   'images/image/detail.html',
                   {'section': 'images',


### PR DESCRIPTION
In the final section of Chapter 6, _Storing a ranking in Redis_, the ranking page was not working for me. It always only showed one result, and it was always only the first image I had ever added to the site (i.e. `id=1`).

I figured out this was because only the first image was being incremented in the call to `redis.Redis.zincrby()`:

https://github.com/PacktPublishing/Django-2-by-Example/blob/e76cca93bfae03d6290fe93d7fe7bdebb78ca7d8/Chapter06/bookmarks/images/views.py#L54

According to the [documentation](https://redis-py.readthedocs.io/en/latest/index.html#redis.Redis.zincrby), the amount to increment is the 2nd argument by position. So the line above always increments `image:1:views` by the integer ID of whatever image is being viewed.

Changing the line to instead increment `image:{image.id}:views` by 1 fixed the issue.
